### PR TITLE
feat: Add Blog, Partners, FAQ, and Careers sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -919,6 +919,138 @@
         </div>
     </section>
 
+    <section class="section" id="blog">
+        <div class="container">
+            <h2 class="section-title">Наш блог</h2>
+            <p class="section-subtitle">Мысли, которыми мы не хотели делиться</p>
+            <div class="blog-grid">
+                <div class="blog-card">
+                    <div class="blog-image">🤔</div>
+                    <div class="blog-content">
+                        <div class="blog-date">3 дня назад</div>
+                        <h3 class="blog-title">Как мы принимаем решения? Подбрасываем монетку</h3>
+                        <p class="blog-excerpt">В этой статье мы раскроем секрет нашего уникального подхода к принятию стратегических решений. Спойлер: орёл — да, решка — тоже да.</p>
+                        <a href="#" class="read-more">Читать далее →</a>
+                    </div>
+                </div>
+                <div class="blog-card">
+                    <div class="blog-image">💡</div>
+                    <div class="blog-content">
+                        <div class="blog-date">1 неделю назад</div>
+                        <h3 class="blog-title">Почему прокрастинация — ключ к успеху</h3>
+                        <p class="blog-excerpt">Мы выяснили, что лучшие идеи приходят в последнюю минуту. Узнайте, как откладывать дела на потом и оставаться продуктивным (нет).</p>
+                        <a href="#" class="read-more">Читать далее →</a>
+                    </div>
+                </div>
+                <div class="blog-card">
+                    <div class="blog-image">🚀</div>
+                    <div class="blog-content">
+                        <div class="blog-date">2 недели назад</div>
+                        <h3 class="blog-title">Запускаем стартап за 24 часа без знаний и денег</h3>
+                        <p class="blog-excerpt">Пошаговое руководство, как создать успешный бизнес, не имея ничего, кроме уверенности в себе. Наш опыт доказывает, что это возможно.</p>
+                        <a href="#" class="read-more">Читать далее →</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="section section-dark" id="partners">
+        <div class="container">
+            <h2 class="section-title">Наши партнёры</h2>
+            <p class="section-subtitle">Компании, которые нам доверяют (по неизвестным причинам)</p>
+            <div class="partners-grid">
+                <div class="partner-logo">Рога и копыта</div>
+                <div class="partner-logo">ООО "Вектор"</div>
+                <div class="partner-logo">НИИ "Прогресс"</div>
+                <div class="partner-logo">Global Innovations</div>
+                <div class="partner-logo">Future Solutions</div>
+            </div>
+        </div>
+    </section>
+
+    <section class="section" id="faq">
+        <div class="container">
+            <h2 class="section-title">Часто задаваемые вопросы</h2>
+            <p class="section-subtitle">Ответы, которые мы придумали на ходу</p>
+            <div class="faq-list">
+                <div class="faq-item">
+                    <div class="faq-question" onclick="toggleFaq(this.parentElement)">
+                        <span>Вы действительно ничего не знаете?</span>
+                        <span class="faq-toggle">+</span>
+                    </div>
+                    <div class="faq-answer">
+                        <p>Абсолютно. Наши знания в любой области стремятся к нулю. Мы считаем, что это позволяет нам смотреть на проблемы свежим, незамутнённым взглядом.</p>
+                    </div>
+                </div>
+                <div class="faq-item">
+                    <div class="faq-question" onclick="toggleFaq(this.parentElement)">
+                        <span>Какие гарантии вы даёте?</span>
+                        <span class="faq-toggle">+</span>
+                    </div>
+                    <div class="faq-answer">
+                        <p>Мы гарантируем, что вы получите красиво оформленную презентацию. За содержание мы ответственности не несём.</p>
+                    </div>
+                </div>
+                <div class="faq-item">
+                    <div class="faq-question" onclick="toggleFaq(this.parentElement)">
+                        <span>Как вы подбираете команду для проекта?</span>
+                        <span class="faq-toggle">+</span>
+                    </div>
+                    <div class="faq-answer">
+                        <p>Мы используем сложный алгоритм, основанный на гороскопах и совместимости знаков зодиака. Это обеспечивает максимальную синергию (или её отсутствие).</p>
+                    </div>
+                </div>
+                <div class="faq-item">
+                    <div class="faq-question" onclick="toggleFaq(this.parentElement)">
+                        <span>Что делать, если ваши советы не сработают?</span>
+                        <span class="faq-toggle">+</span>
+                    </div>
+                    <div class="faq-answer">
+                        <p>В этом случае вы сможете с уверенностью сказать, что попробовали нестандартный подход. А это уже ценный опыт.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="section section-dark" id="careers">
+        <div class="container">
+            <h2 class="section-title">Вакансии</h2>
+            <p class="section-subtitle">Присоединяйтесь к команде, где от вас ничего не ждут</p>
+            <div class="jobs-list">
+                <div class="job-card">
+                    <div class="job-header">
+                        <h3 class="job-title">Специалист по откладыванию задач</h3>
+                        <div class="job-type">Полный рабочий день</div>
+                    </div>
+                    <div class="job-meta">
+                        <div class="job-meta-item">📍 Удалённо</div>
+                        <div class="job-meta-item">💼 Отдел прокрастинации</div>
+                    </div>
+                    <div class="job-description">
+                        Ищем мотивированного (не обязательно) сотрудника для откладывания важных дел на неопределённый срок.
+                    </div>
+                    <button class="apply-button" onclick="showJobModal('Специалист по откладыванию задач')">ОТКЛИКНУТЬСЯ</button>
+                </div>
+                <div class="job-card">
+                    <div class="job-header">
+                        <h3 class="job-title">Менеджер по созданию видимости работы</h3>
+                        <div class="job-type">Гибкий график</div>
+                    </div>
+                    <div class="job-meta">
+                        <div class="job-meta-item">📍 Офис</div>
+                        <div class="job-meta-item">💼 Департамент имитации бурной деятельности</div>
+                    </div>
+                    <div class="job-description">
+                        Требуется эксперт по организации бессмысленных совещаний и ведению деловой переписки без конкретики.
+                    </div>
+                    <button class="apply-button" onclick="showJobModal('Менеджер по созданию видимости работы')">ОТКЛИКНУТЬСЯ</button>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <section class="section" id="pricing">
         <div class="container">
             <h2 class="section-title">Тарифы</h2>


### PR DESCRIPTION
This commit introduces four new content sections to the single-page website to fulfill the user's request for more content and visual improvements.

The following sections have been added:
- A "Blog" section with satirical posts.
- A "Partners" section with fictional company logos.
- An interactive "FAQ" section with an accordion-style implementation.
- A "Careers" section listing comical job openings.

All new sections are implemented using the existing CSS classes and JavaScript functions found within the `index.html` file, ensuring a consistent design and functionality. The content is placed logically within the page flow to align with the navigation bar.